### PR TITLE
Fix usage of weird python basename() (returns nothing for paths with trailing slashes!).

### DIFF
--- a/pycp/transfer.py
+++ b/pycp/transfer.py
@@ -166,7 +166,8 @@ class TransferInfo():
         """
         debug(":: file %s -> %s" % (source, destination))
         if os.path.isdir(destination):
-            destination = os.path.join(destination, os.path.basename(source))
+            destination = os.path.join(destination,
+                                       os.path.basename(os.path.normpath(source)))
         self.add(source, destination)
 
     def _parse_dir(self, source, destination):
@@ -175,7 +176,7 @@ class TransferInfo():
         """
         debug(":: dir %s -> %s" % (source, destination))
         if os.path.isdir(destination):
-            destination = os.path.join(destination, os.path.basename(source))
+            destination = os.path.join(destination, os.path.basename(os.path.normpath(source)))
         debug(":: making dir %s" % destination)
         if not os.path.exists(destination):
             os.mkdir(destination)


### PR DESCRIPTION
This was leading to different results than conventional cp and mv. Ie

```
$ # Directory heirarchy to to make things somewhat less contrived
$ mkdir testdst
$ touch testdst/dstfile
$ mkdir testsrc
$ touch testsrc/srcfile
$ mv testsrc/ testdst/ #the trailing slashes come from autocomplete
$ ls testdst/
dstfile  testsrc
$ mv testdst/testsrc . #reset
$ pymv testsrc/ testdst/
$ ls testdst/
destfile  srcfile
```

The problem is os.path.basename being befferent than the posix basename.
This is actually documented somewhere, I don't have the references on hand
though. It is easy to fix though, just add a os.path.normpath:

```
>>> import os
>>> t1="/foo/bar/qux"
>>> t2="/foor/bar/qux/"
>>> t2="/foo/bar/qux/"
>>> t3="projects"
>>> t4="projects/"
>>> for i in [t1, t2, t3, t4]: print i, "=>", os.path.basename(i)
...
/foo/bar/qux => qux
/foo/bar/qux/ =>
projects => projects
projects/ =>
>>> for i in [t1, t2, t3, t4]: print i, "=>", os.path.basename(os.path.normpath(i))
...
/foo/bar/qux => qux
/foo/bar/qux/ => qux
projects => projects
projects/ => projects
```
